### PR TITLE
Lssttd 788 patch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.lsst.camera</groupId>
     <artifactId>org-lsst-camera-portal-web</artifactId>
-    <version>0.2.7</version>
+    <version>0.2.8</version>
     <packaging>war</packaging>
     <name>LSST Camera Data Portal</name>    
 

--- a/src/main/webapp/SensorAcceptanceReport.jsp
+++ b/src/main/webapp/SensorAcceptanceReport.jsp
@@ -176,10 +176,10 @@
                 <h2>Summary</h2>
                 <c:choose>
                     <c:when test="${HaveTS3Data}"> <%-- It is very likely this sensor has no TS3 data --%>
-                        <c:set var="theMap2" value="${portal:getReportValues(pageContext.session,vendActId,reportId)}"/>
+                        <c:set var="theMap2" value="${portal:getReportValues(pageContext.session,pActId2,reportId)}"/>
                         <c:choose>
                             <c:when test="${HaveVendData}"> 
-                                <c:set var="theMapVend" value="${portal:getReportValues(pageContext.session,pActId2,reportId)}"/>
+                                <c:set var="theMapVend" value="${portal:getReportValues(pageContext.session,vendActId,reportId)}"/>
                                 <dp:acceptance sectionNum="1" data="${theMap}" dataTS3="${theMap2}" dataVend="${theMapVend}" reportId="${reportId}"/>
                             </c:when>
                             <c:otherwise>


### PR DESCRIPTION
emergency patch to the sensor acceptance pages to fix bug when displaying data from all 3 sources (SR-RCV-1, SR-EOT-02, SR-EOT-01) where the vendor and TS3 data are swapped in the table.