### PR TITLE
Lssttd 825

### DIFF
--- a/src/main/webapp/RawReport.jsp
+++ b/src/main/webapp/RawReport.jsp
@@ -22,25 +22,14 @@
         <fmt:setTimeZone value="UTC"/>
         <ru:printButton/>
         <sql:query var="sensor">
-            select hw.lsstId, act.end, act.id, pr.name from Activity act 
+            select hw.lsstId from Activity act 
             join Hardware hw on act.hardwareId=hw.id 
-            join Process pr on act.processId=pr.id 
-            join ActivityStatusHistory statusHist on act.id=statusHist.activityId 
-            where statusHist.activityStatusId=1 and act.id = ?
-            <sql:param value="${param.parentActivityId}"/>
+            join RunNumber r on r.rootActivityId=act.id
+            where r.runNumber=?
+            <sql:param value="${param.run}"/>
         </sql:query> 
         <c:set var="lsstId" value="${sensor.rows[0].lsstId}"/>  
-        <c:set var="actId" value="${sensor.rows[0].id}"/>  
-        <c:set var="end" value="${sensor.rows[0].end}"/>  
-        <c:set var="reportName" value="${sensor.rows[0].name}"/>
-        <c:set var="parentActivityId" value="${param.parentActivityId}"/>
-        <sql:query var="reports" dataSource="jdbc/config-prod">
-            select id from report where name=?
-            <sql:param value="${reportName}"/>
-        </sql:query>
-
-        <h1>Raw Report for ${lsstId}</h1>
-        Generated <fmt:formatDate value="${end}" pattern="yyy-MM-dd HH:mm z"/> by Job Id <ru:jobLink id="${actId}"/>
+        <h1>Raw Report for ${lsstId} run <a href="run.jsp?run=${param.run}">${param.run}</a></h1>
         <sql:query var="data">
             select p.name, x.variable,x.value,x.type from (
                 select res.activityId, res.name variable, res.value, "String" type from StringResultHarnessed res 
@@ -53,8 +42,9 @@
             ) x
             join Activity act on x.activityId=act.id 
             join Process p on act.processid=p.id
-            where act.parentActivityId=?
-            <sql:param value="${param.parentActivityId}"/>
+            join RunNumber r on r.rootActivityId=act.rootActivityId
+            where r.runNumber=?
+            <sql:param value="${param.run}"/>
         </sql:query>
         <display:table name="${data.rows}"   class="datatable" >
             <display:column property="name" title="Process"/>

--- a/src/main/webapp/run.jsp
+++ b/src/main/webapp/run.jsp
@@ -1,0 +1,83 @@
+<%@page contentType="text/html"%>
+<%@page pageEncoding="UTF-8"%>
+<%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@taglib uri="http://java.sun.com/jsp/jstl/sql" prefix="sql" %>
+<%@taglib uri="http://displaytag.sf.net" prefix="display" %>
+<%@taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
+<%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@taglib prefix="file" uri="http://portal.lsst.org/fileutils" %>
+<%@taglib uri="http://srs.slac.stanford.edu/filter" prefix="filter"%>
+<%@taglib uri="http://srs.slac.stanford.edu/utils" prefix="utils"%>
+
+<%-- 
+    One stop shop for run related info
+    Document   : runList.jsp
+    Created on : Sep 18, 2016, 5:32:51 PM
+    Author     : tonyj
+--%>
+
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>eTraveler Run ${param.run}</title>
+    </head>
+    <body>
+        <h1>eTraveler Run ${param.run}</h1>
+        <fmt:setTimeZone value="UTC"/>
+
+        <sql:query var="result">
+            select * from (
+            select r.runInt,r.runNumber,a.begin,a.end,a.id,p.name ,h.lsstid,h.manufacturer,f.name as status, t.name hardwareType,ss.name subsystem,i.name Site,
+            (select count(*) from Activity aa join FilepathResultHarnessed ff on (aa.id=ff.activityId) where aa.rootActivityId=a.id) as fileCount,
+            (select count(*) from Activity aa join FloatResultHarnessed ff on (aa.id=ff.activityId) where aa.rootActivityId=a.id) as floatCount,
+            (select count(*) from Activity aa join IntResultHarnessed ff on (aa.id=ff.activityId) where aa.rootActivityId=a.id) as intCount,
+            (select count(*) from Activity aa join StringResultHarnessed ff on (aa.id=ff.activityId) where aa.rootActivityId=a.id) as StringCount
+            from Activity a 
+            join Process p on (a.processId=p.id)
+            join Hardware h on (a.hardwareId=h.id)
+            join HardwareType t on (h.hardwareTypeId = t.id)
+            join TravelerType tt on (p.id=tt.rootProcessId)
+            join Subsystem ss on (ss.id=tt.subsystemId)
+            join ActivityStatusHistory s on (s.id = (select max(id) from ActivityStatusHistory ss where ss.activityId=a.id))
+            join ActivityFinalStatus f on (f.id=s.activityStatusId)
+            join HardwareLocationHistory hlh on (hlh.id= (select max(id) from HardwareLocationHistory ll where ll.id=h.id and (a.end is null or ll.creationTS < a.end)))
+            join Location l on (l.id=hlh.locationId)
+            join Site i on (i.id=l.siteId)
+            join RunNumber r on (r.rootActivityId=a.id)
+            where a.parentActivityId is null 
+            and r.runInt = ?
+            ) x
+            <sql:param value="${param.run}"/>
+        </sql:query>
+        <c:set var="run" value="${result.rows[0]}"/>
+
+        <h2>Summary</h2>
+        <table class="datatable">
+            <utils:trEvenOdd reset="true"><th>Run Number</th><td>${run.runNumber}</td></utils:trEvenOdd>
+            <utils:trEvenOdd><th>Traveler</th><td><a href="/eTraveler/displayActivity.jsp?activityId=${run.id}">${run.name}</a></td></utils:trEvenOdd>
+            <utils:trEvenOdd><th>Device Type</th><td>${run.hardwareType}</td></utils:trEvenOdd>
+            <utils:trEvenOdd><th>Device</th><td>${run.lsstid}</td></utils:trEvenOdd>
+            <utils:trEvenOdd><th>Status</th><td>${run.status}</td></utils:trEvenOdd>
+            <utils:trEvenOdd><th>Subsystem</th><td>${run.subsystem}</td></utils:trEvenOdd>
+            <utils:trEvenOdd><th>Site</th><td>${run.site}</td></utils:trEvenOdd>
+            <utils:trEvenOdd><th>Begin</th><td><fmt:formatDate value="${run.begin}" pattern="yyyy-MM-dd HH:mm:ss"/></td></utils:trEvenOdd>
+            <utils:trEvenOdd><th>End</th><td><fmt:formatDate value="${run.end}" pattern="yyyy-MM-dd HH:mm:ss"/></td></utils:trEvenOdd>
+            </table>
+
+        <c:if test="${run.fileCount+run.floatCount+run.intCount+run.StringCount>0}">
+            <h2>Reports</h2>
+            <ul>
+                <li><a href="RawReport.jsp?run=${param.run}">Raw Report</a> (data dump)</li>
+                <c:if test="${run.name=='SR-EOT-02'}"><li><a href="SummaryReport.jsp?run=${param.run}">EOTest Report</a></li></c:if>
+            </ul>
+        </c:if>
+
+        <c:if test="${run.fileCount+run.floatCount+run.intCount+run.StringCount>0}">
+            <h2>Files</h2>
+            <ul>
+                <li><a href="runFiles.jsp?run=${param.run}">Files</a></li>
+            </ul>            
+        </c:if>
+    </body>
+</html>

--- a/src/main/webapp/run.jsp
+++ b/src/main/webapp/run.jsp
@@ -70,6 +70,7 @@
             <ul>
                 <li><a href="RawReport.jsp?run=${param.run}">Raw Report</a> (data dump)</li>
                 <c:if test="${run.name=='SR-EOT-02'}"><li><a href="SummaryReport.jsp?run=${param.run}">EOTest Report</a></li></c:if>
+                <c:if test="${run.name=='SR-RSA-MET-07'}"><li><a href="SummaryReport.jsp?run=${param.run}">Metrology Report</a></li></c:if>
             </ul>
         </c:if>
 

--- a/src/main/webapp/runList.jsp
+++ b/src/main/webapp/runList.jsp
@@ -155,6 +155,12 @@
                         </c:url>
                         <a href="${report}">EO</a>
                     </c:if>
+                    <c:if test="${run.name=='SR-RSA-MET-07'}">
+                        <c:url var="report" value="SummaryReport.jsp">
+                            <c:param name="run" value="${run.runNumber}"/>
+                        </c:url>
+                        <a href="${report}">MET</a>
+                    </c:if>
                 </c:if>
             </display:column>
             <display:column title="Links" class="leftAligned">

--- a/src/main/webapp/runList.jsp
+++ b/src/main/webapp/runList.jsp
@@ -23,10 +23,7 @@
     </head>
     <body>
         <h1>eTraveler Runs</h1>
-        <fmt:setTimeZone value="UTC"/>
-        
-        <b>Note:</b> There are currently no run numbers in prod, switch to dev to see anything.
-        
+        <fmt:setTimeZone value="UTC"/>   
         <filter:filterTable>
             <filter:filterCheckbox title="Most Recent" var="mostRecent" defaultValue="true"/>
             <filter:filterSelection title="Status" var="status" defaultValue='-1'>
@@ -77,7 +74,10 @@
         <sql:query var="runs">
             select * from (
             select r.runInt,r.runNumber,a.begin,a.end,p.name ,h.lsstid,h.manufacturer,f.name as status, t.name hardwareType,ss.name subsystem,i.name Site,
-            (select count(*) from Activity aa join FilepathResultHarnessed ff on (aa.id=ff.activityId) where aa.rootActivityId=a.id) as fileCount
+            (select count(*) from Activity aa join FilepathResultHarnessed ff on (aa.id=ff.activityId) where aa.rootActivityId=a.id) as fileCount,
+            (select count(*) from Activity aa join FloatResultHarnessed ff on (aa.id=ff.activityId) where aa.rootActivityId=a.id) as floatCount,
+            (select count(*) from Activity aa join IntResultHarnessed ff on (aa.id=ff.activityId) where aa.rootActivityId=a.id) as intCount,
+            (select count(*) from Activity aa join StringResultHarnessed ff on (aa.id=ff.activityId) where aa.rootActivityId=a.id) as StringCount
             from Activity a 
             join Process p on (a.processId=p.id)
             join Hardware h on (a.hardwareId=h.id)
@@ -130,7 +130,7 @@
         </sql:query>
 
         <display:table name="${runs.rows}" sort="list" defaultsort="1" defaultorder="descending" class="datatable" id="run" >
-            <display:column property="runNumber" sortProperty="runInt" title="Run" sortable="true"/>
+            <display:column property="runNumber" sortProperty="runInt" title="Run" sortable="true" href="run.jsp" paramId="run"/>
             <display:column property="name" title="Traveler" sortable="true"/>
             <display:column property="hardwareType" title="Device Type" sortable="true"/>
             <display:column property="lsstid" title="Device" sortable="true"/>
@@ -142,6 +142,20 @@
             </display:column>
             <display:column sortProperty="end" title="End (UTC)" sortable="true">
                 <fmt:formatDate value="${run.end}" pattern="yyyy-MM-dd HH:mm:ss"/>
+            </display:column>
+            <display:column title="Reports" class="leftAligned">
+                <c:if test="${run.fileCount+run.floatCount+run.intCount+run.StringCount>0}">
+                    <c:url var="report" value="RawReport.jsp">
+                        <c:param name="run" value="${run.runNumber}"/>
+                    </c:url>
+                    <a href="${report}">Raw</a> 
+                    <c:if test="${run.name=='SR-EOT-02'}">
+                        <c:url var="report" value="SummaryReport.jsp">
+                            <c:param name="run" value="${run.runNumber}"/>
+                        </c:url>
+                        <a href="${report}">EO</a>
+                    </c:if>
+                </c:if>
             </display:column>
             <display:column title="Links" class="leftAligned">
                 <c:if test="${run.fileCount>0}">


### PR DESCRIPTION
This pull request implement's LSSTD-825 (Add links to reports from Run Centric Index). See for an example: 

http://lsst-camera-dev.slac.stanford.edu/DataPortal-tonyj/runList.jsp

It also 
* Introduces a new page, e.g.: http://lsst-camera-dev.slac.stanford.edu/DataPortal-tonyj/run.jsp?run=2418
* Makes the run-centric report pages use ?run=xxxx rather than ?parentActivity=xxxx

This fix is ready to go to prod (probably along with other changes for MET reports which are coming from Charlotte), although it is a slight kludge because currently the report links are hardwired into the runList.jsp and run.jsp pages, instead of being database generated. This will be fixed in a future JIRA.